### PR TITLE
Fix role renaming

### DIFF
--- a/plugin.php
+++ b/plugin.php
@@ -183,7 +183,7 @@ final class Roles {
         $wp_roles->role_names[ $name ]    = $new_display_name;
 
         // Update also geniem roles instance name.
-        self::$roles[ $name ]->name = $new_display_name;
+        self::$roles[ $name ]->display_name = $new_display_name;
     }
 
     /**


### PR DESCRIPTION
Role has wrong name after renaming.

For example, if we rename the `administrator` role like this
```
$administrator = \Geniem\Roles::get( 'administrator' );
$administrator->rename( ‘Ylläpitäjä’ );
```
then `$this->name` will be “Ylläpitäjä” when it should be `administrator`. This PR fixes this and doesn’t change the name (which is actually a role slug), but display name only and the `$this->name` reference is intact.

Currently, e.g. `$administrator->remove_menu_pages( […] );` doesn’t work because `$this->name` is wrong.